### PR TITLE
Added permissions policy section before role creation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,40 +44,40 @@ The following is a sample request payload for a DynamoDB read item operation:
 
 ## Setup
 
-### Create Custom Permissions Policy that will be used by the Lambda IAM Role below
+### Create Custom Permissions Policy that will be used by the Lambda execution role below
 1. Go to IAM Console. Under Access Management, click on "Policies".
 2. Click "Create policy"
 3. Click "JSON"
 4. In the policy editor, paste the following:
     ```json
     {
-    "Version": "2012-10-17",
-    "Statement": [
-    {
-      "Sid": "Stmt1428341300017",
-      "Action": [
-        "dynamodb:DeleteItem",
-        "dynamodb:GetItem",
-        "dynamodb:PutItem",
-        "dynamodb:Query",
-        "dynamodb:Scan",
-        "dynamodb:UpdateItem"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    },
-    {
-      "Sid": "",
-      "Resource": "*",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Effect": "Allow"
-    }
-    ]
-    }
+		"Version": "2012-10-17",
+		"Statement": [
+			{
+				"Action": [
+					"dynamodb:DeleteItem",
+					"dynamodb:GetItem",
+					"dynamodb:PutItem",
+					"dynamodb:Query",
+					"dynamodb:Scan",
+					"dynamodb:UpdateItem"
+				],
+				"Effect": "Allow",
+				"Resource": "*",
+				"Sid": "stmt_ddb_permissions"
+			},
+			{
+				"Action": [
+					"logs:CreateLogGroup",
+					"logs:CreateLogStream",
+					"logs:PutLogEvents"
+				],
+				"Effect": "Allow",
+				"Resource": "*",
+				"Sid": "stmt_cwlogs_permissions"
+			}
+		]
+	}
     ```
 5. Click Next.
 6. Set policy name as **lambda-apigateway-policy**

--- a/README.md
+++ b/README.md
@@ -44,17 +44,11 @@ The following is a sample request payload for a DynamoDB read item operation:
 
 ## Setup
 
-### Create Lambda IAM Role 
-Create the execution role that gives your function permission to access AWS resources.
-
-To create an execution role
-
-1. Open the roles page in the IAM console.
-2. Choose Create role.
-3. Create a role with the following properties.
-    * Trusted entity – Lambda.
-    * Role name – **lambda-apigateway-role**.
-    * Permissions – Custom policy with permission to DynamoDB and CloudWatch Logs. This custom policy has the permissions that  the function needs to write data to DynamoDB and upload logs. 
+### Create Custom Permissions Policy that will be used by the Lambda IAM Role below
+1. Go to IAM Console. Under Access Management, click on "Policies".
+2. Click "Create policy"
+3. Click "JSON"
+4. In the policy editor, paste the following:
     ```json
     {
     "Version": "2012-10-17",
@@ -85,6 +79,25 @@ To create an execution role
     ]
     }
     ```
+5. Click Next.
+6. Set policy name as **lambda-apigateway-policy**
+5. Click "Create policy".
+
+### Create Lambda IAM Role 
+Create the execution role that gives your function permission to access AWS resources.
+
+To create an execution role
+
+1. Open the roles page in the IAM console.
+2. Click Create role.
+3. Create a role with the following properties.
+    * Trusted entity type – AWS Service
+    * Use Case > Service or use case - Select Lambda. Click Next.
+    * On Add Permissions page, search for policy name you created in the previous step.
+    * Select the checkbox for the policy. Click Next. 
+    * Role name – **lambda-apigateway-role**.
+    * Click "Create role". 
+       
 
 ### Create Lambda Function
 


### PR DESCRIPTION
1. Added an initial section to first create a policy that will be used by the role (to be created next).
2. Updated role creation to refer to the policy that was created in the previous step.
3. Formatted permissions policy.